### PR TITLE
Add current date so only events for today are shown

### DIFF
--- a/events_api.py
+++ b/events_api.py
@@ -4,7 +4,7 @@ from decouple import config
 
 def getEvents(lat, long):
   events_token = config('EVENTFUL_API_KEY')
-  events_request = requests.get('http://api.eventful.com/json/events/search?...&where='+lat+','+long+'&within=20&app_key='+events_token+'')
+  events_request = requests.get('http://api.eventful.com/json/events/search?...&where='+lat+','+long+'&within=20&app_key='+events_token+'&date=Today')
   events_json = events_request.json()
   hashy = {
           'event_one':


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes

I did not have the current date param in the events search, which is crucial for the functioning of our app. the app will only suggest events for the current day if weather permits, so without the param for the current date, the events displayed could be for random days. 

Travis CI build passed. Coverage at 97%